### PR TITLE
Add continuous integration (AppVeyor & Travis CI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: rust
+
+rust:
+ - stable
+ - beta
+ - nightly
+
+matrix:
+  allow_failures:
+    - rust: nightly
+    
+install: cargo build --release --verbose
+
+script: cargo test --verbose

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-
-
+[![Travis CI build Status][travis-image]][travis-url]
+[![AppVeyor build Status][appveyor-image]][appveyor-url]
 
 https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-marshaling
+
+
+
+[travis-url]: https://travis-ci.org/marcelbuesing/dbus-native
+[travis-image]: https://travis-ci.org/marcelbuesing/dbus-native.svg?branch=master
+
+[appveyor-url]: (https://ci.appveyor.com/project/marcelbuesing/dbus-native)
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/github/marcelbuesing/dbus-native?branch=master&svg=true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+image: Visual Studio 2017
+
+environment:
+  host: x86_64-pc-windows-msvc        # Triple of host platform
+  matrix:
+    - platform: x86_64                # Name (is not used other than naming things)
+      target: x86_64-pc-windows-msvc  # Triple of target platform
+      channel: stable                 # Rust release channel (stable/beta/nightly/nightly-2018-12-01)
+    - platform: arm64
+      target: aarch64-pc-windows-msvc 
+      channel: stable
+matrix:
+  allow_failures:                     # Allows jobs with these variables to fail
+    - platform: arm64
+
+install:
+    - git submodule update --init
+    - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe  # Downloads Rustup-init 
+    - rustup-init -yv --default-toolchain %channel% --default-host %host%     # Installs Rust
+    - set PATH=%PATH%;%USERPROFILE%\.cargo\bin;%APPVEYOR_BUILD_FOLDER%        # Adds Rust tools (Cargo, Rustup, etc.) to path
+    - rustc -vV                       # Prints Rust version
+    - cargo -vV                       # Prints Cargo version
+    - rustup target add %target%      # Adds target platform to Rust
+
+build_script:
+    - cargo build --release --target=%target%      # Builds file defined in Cargo.toml (default main.rs)
+
+test_script:
+    - cargo test --target=%target% --verbose       # Runs tests in "src" and "tests" folders
+#    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
+
+artifacts:                          
+    - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
+      name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
+      
+deploy:
+  - provider: GitHub
+    artifact: $(APPVEYOR_PROJECT_NAME)-$(platform)
+    auth_token:
+      secure: 'hY5Mk6KOwgQ97TzEBsM7Woqr1ZIm5QTvHg8EvxMV1x8j3wk/3mNBMqWFFbEIBK0i'
+    prerelease: true
+    on:
+      appveyor_repo_tag: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ test_script:
 #    - cargo bench --target=%target% --verbose      # Runs benchmarks in "src/lib.rs"
 
 artifacts:                          
-    - path: target\$(target)\release\*$(APPVEYOR_PROJECT_NAME)*.*     # Publishes all files from `cargo build/test/bench --release`
+    - path: target\$(target)\release\*dbus*.*     # Publishes all files from `cargo build/test/bench --release`
       name: $(APPVEYOR_PROJECT_NAME)-$(platform)                      # Gives it a fancy name
       
 deploy:


### PR DESCRIPTION
Adds continuous integration with both AppVeyor and Travis CI. 

For optimal integration with GitHub, [AppVeyor](https://github.com/marketplace/appveyor) and [Travis CI](https://github.com/marketplace/travis-ci) needs to be enabled on the GitHub Marketplace.

AppVeyor builds & tests on Windows with Rust stable, while Travis builds & tests on Linux with Rust stable, beta & nightly. 

AppVeyor also publishes the artifacts with each build. When tagging a new (pre)release, AppVeyor will also upload `libdbus_native.d` and `libdbus_native.rlib` to GitHub, creating a release page [like this](https://github.com/EwoutH/dbus-native/releases/tag/0.0.1-test1).

To enable uploading to GitHub Releases, you need update this patch with your personal authentication token. You can generate one on https://github.com/settings/tokens/new (select `public_repo` as scope), and then encrypt it with https://ci.appveyor.com/tools/encrypt. Replace the current token on line 40 (after `secure:`) in the `appveyor.yml` file. 